### PR TITLE
Added docs about WIRINGPI_CODES environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ a pin based GPIO access library written in C.
 You can grab the latest version of PowerShell IoT by running:
 
 ```powershell
-sudo pwsh
+sudo WIRINGPI_CODES=1 pwsh
 Install-Module Microsoft.PowerShell.IoT
 ```
 
@@ -133,8 +133,13 @@ _NOTE: If you'd rather not use the script, simply copy the `out/Microsoft.PowerS
 First, you must run pwsh with sudo:
 
 ```powershell
-sudo pwsh
+sudo WIRINGPI_CODES=1 pwsh
 ```
+
+##### About `WIRINGPI_CODES` environment variable
+
+`Microsoft.PowerShell.IoT` module internally uses [WiringPi library](http://wiringpi.com/reference/setup) which has a default behavior of terminating current process (in this case - PowerShell) even on non-critical errors in setup functions.
+To avoid such crashes define `WIRINGPI_CODES` environment variable either when starting PowerShell (see example above) or through configuration scripts - example for an interactive login shell - `echo "export WIRINGPI_CODES=1"|sudo tee -a /etc/profile.d/WiringPiCodes.sh`
 
 If you have the `Microsoft.PowerShell.IoT` module in your PSModulePath:
 


### PR DESCRIPTION
WiringPi library has a default behavior of terminating current process (e.g. PowerShell) even on non-critical errors in setup functions. For example:

`pwsh will crash and throw the error Unable to select I2C device: Device or resource busy.`

```powershell
Get-I2CDevice -Id 911 #Or some other value that isn't valid
# pwsh will crash, throwing the error Unable to select I2C device: Invalid argument.
```

This PR adds doc instructions on how to avoid such crashes.