### PR TITLE
Add more settings to SPI, and possibly add a Get-SPIDevice

### DIFF
--- a/src/Microsoft.PowerShell.IoT/SPI/Get/GetSPIDevice.cs
+++ b/src/Microsoft.PowerShell.IoT/SPI/Get/GetSPIDevice.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Management.Automation;
+using System.Device.Spi;
+using System.Device.Gpio;
+
+[Cmdlet(VerbsCommon.Get, "SPIDevice")]
+public class GetSPIDevice : Cmdlet
+{
+
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 0)]
+    public int BusId { get; set; }
+
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 1)]
+    public int ChipSelectLine { get; set; }
+
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 2)]
+    public int Frequency { get; set; }
+
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 3)]
+    public int DataBitLength { get; set;}
+
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 4)]
+    public SpiMode Mode { get; set; }
+
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 5)]
+    public DataFlow DataFlow { get; set; }
+
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 6)]
+    public PinValue ChipSelectLineActiveState { get; set; }
+
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true)]
+    public SwitchParameter Raw { get; set; }
+
+    public GetSPIDevice()
+    {
+        this.BusId = 0;
+        this.ChipSelectLine = 0;
+        this.Frequency = 500_000; // 500 KHz default speed
+    }
+
+    protected override void ProcessRecord()
+    {
+        var settings = new SpiConnectionSettings(this.BusId, this.ChipSelectLine)
+        {
+            ClockFrequency = this.Frequency,
+            DataBitLength = this.DataBitLength,
+            Mode = this.Mode,
+            DataFlow = this.DataFlow,
+            ChipSelectLineActiveState = this.ChipSelectLineActiveState
+        };
+
+        SpiDevice spiDevice = SpiDevice.Create(settings);
+        //TODO: This can be done this way if we follow the same logic as in I2C where we access the device by doing device.Device
+        // WriteObject(new SPIDevice(spiDevice, this.BusId, this.ChipSelectLine, this.Frequency, 
+        //                             this.DataBitLength, this.Mode, this.DataFlow, 
+        //                             this.ChipSelectLineActiveState));
+        //Because I'm currently testing this like this : $device = Get-SPIDevice -Frequency 2400000 -Mode Mode0 -DataBitLength 8 -BusId 0 -ChipSelectLine 0
+        // I want the returned object to be the spiDevice created.
+        WriteObject(spiDevice);
+        
+    }
+}

--- a/src/Microsoft.PowerShell.IoT/SPI/SPIData.cs
+++ b/src/Microsoft.PowerShell.IoT/SPI/SPIData.cs
@@ -1,16 +1,34 @@
-public class SPIData
+// public class SPIData
+// {
+//     public int BusId { get; set; }
+//     public int ChipSelectLine { get; set; }
+//     public int Frequency { get; set; }
+//     public byte[] Data { get; set; }
+//     public byte[] Response { get; set; }
+
+//     public SPIData(int busId, int chipSelectLine, int frequency, byte[] data, byte[] response)
+//     {
+//         this.BusId = busId;
+//         this.ChipSelectLine = chipSelectLine;
+//         this.Frequency = frequency;
+//         this.Data = data;
+//         this.Response = response;
+//     }
+// }
+
+using System.Device.Gpio;
+using System.Device.Spi;
+
+public class SPIData : SPIDevice
 {
-    public int BusId { get; set; }
-    public int ChipSelectLine { get; set; }
-    public int Frequency { get; set; }
     public byte[] Data { get; set; }
     public byte[] Response { get; set; }
 
-    public SPIData(int busId, int chipSelectLine, int frequency, byte[] data, byte[] response)
+    public SPIData(SpiDevice device, int busId, int chipSelectLine, int frequency, 
+                   int dataBitLength, SpiMode mode, DataFlow dataFlow, 
+                   PinValue chipSelectLineActiveState, byte[] data, byte[] response
+                  ): base(device, busId, chipSelectLine, frequency, dataBitLength, mode, dataFlow, chipSelectLineActiveState)
     {
-        this.BusId = busId;
-        this.ChipSelectLine = chipSelectLine;
-        this.Frequency = frequency;
         this.Data = data;
         this.Response = response;
     }

--- a/src/Microsoft.PowerShell.IoT/SPI/SPIDevice.cs
+++ b/src/Microsoft.PowerShell.IoT/SPI/SPIDevice.cs
@@ -1,0 +1,34 @@
+using System.Device.Gpio;
+using System.Device.Spi;
+
+public class SPIDevice
+{
+    internal SpiDevice device = null;
+    public int BusId { get; set; }
+
+    public int ChipSelectLine { get; set; }
+
+    public int Frequency { get; set; }
+
+    public int DataBitLength { get; set;}
+
+    public SpiMode Mode { get; set; }
+
+    public DataFlow DataFlow { get; set; }
+
+    public PinValue ChipSelectLineActiveState { get; set; }
+
+    public SPIDevice(SpiDevice device, int busId, int chipSelectLine, int frequency, 
+                     int dataBitLength, SpiMode mode, DataFlow dataFlow, 
+                     PinValue chipSelectLineActiveState)
+    {
+        this.device = device;
+        this.BusId = busId;
+        this.ChipSelectLine = chipSelectLine;
+        this.Frequency = frequency;
+        this.DataBitLength = dataBitLength;
+        this.Mode = mode;
+        this.DataFlow = dataFlow;
+        this.ChipSelectLineActiveState = chipSelectLineActiveState;        
+    }
+}

--- a/src/Microsoft.PowerShell.IoT/SPI/Send/SendSPIData.cs
+++ b/src/Microsoft.PowerShell.IoT/SPI/Send/SendSPIData.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Management.Automation;
 using System.Device.Spi;
+using System.Device.Gpio;
 
 [Cmdlet(VerbsCommunications.Send, "SPIData")]
 public class SendSPIData : Cmdlet
@@ -17,6 +18,18 @@ public class SendSPIData : Cmdlet
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 3)]
     public int Frequency { get; set; }
 
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 4)]
+    public int DataBitLength { get; set;}
+
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 5)]
+    public SpiMode Mode { get; set; }
+
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 6)]
+    public DataFlow DataFlow { get; set; }
+
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, Position = 7)]
+    public PinValue ChipSelectLineActiveState { get; set; }
+
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true)]
     public SwitchParameter Raw { get; set; }
 
@@ -29,10 +42,16 @@ public class SendSPIData : Cmdlet
 
     protected override void ProcessRecord()
     {
-        var settings = new SpiConnectionSettings(this.BusId, this.ChipSelectLine);
-        settings.ClockFrequency = this.Frequency;
-        
-        using(var spiDevice = SpiDevice.Create(settings))
+        var settings = new SpiConnectionSettings(this.BusId, this.ChipSelectLine)
+        {
+            ClockFrequency = this.Frequency,
+            DataBitLength = this.DataBitLength,
+            Mode = this.Mode,
+            DataFlow = this.DataFlow,
+            ChipSelectLineActiveState = this.ChipSelectLineActiveState
+        };
+
+        using (var spiDevice = SpiDevice.Create(settings))
         {
             var response = new byte[this.Data.Length];
 
@@ -44,7 +63,10 @@ public class SendSPIData : Cmdlet
             }
             else
             {
-                SPIData spiData = new SPIData(this.BusId, this.ChipSelectLine, this.Frequency, this.Data, response);
+                SPIData spiData = new SPIData(spiDevice, this.BusId, this.ChipSelectLine, this.Frequency, 
+                                                  this.DataBitLength, this.Mode, this.DataFlow, 
+                                                  this.ChipSelectLineActiveState, this.Data, response);
+                //SPIData spiData = new SPIData(this.BusId, this.ChipSelectLine, this.Frequency, this.Data, response);
                 WriteObject(spiData);
             }
         }


### PR DESCRIPTION
This is an initial commit so that we can discuss if such changes can make sense.
This comes in sequence of issue #53. In my case, I have the neopixels which I can use to test the SPI, basing my implementation on [dotnet IoT binding sample for the WS2812b](https://github.com/dotnet/iot/blob/master/src/devices/Ws28xx/samples/Ws28xx.Sample.cs).
* Why a Get-SPIDevice - For this binding, they are passing the SPI device as a parameter (which was one of the reasons why I've decided to try an implementation of a Get-SPIDevice). It also seems, as I've pointed on the issue, that "this seems that the SPI device could be created once and used many times", which would make more sense than creating a device for each time we send some data.

* Why more settings - Again, basing my implementation on their sample, there were some settings that seemed to be mandatory for it to work properly. Because it seems they are not mandatory, they can be created with default values.

Here's an example:
```powershell
$device = Get-SPIDevice -Frequency 2400000 -Mode Mode0 -DataBitLength 8 -BusId 0 -ChipSelectLine 0
	$neo = [Iot.Device.Ws28xx.Ws2812b]::new($device,1)                              
	$img = $neo.Image
	$img.SetPixel(0,0, [System.Drawing.Color]::DarkRed)
	$neo.Update()    
```