### PR TITLE
Fixed dead links

### DIFF
--- a/Examples/Microsoft.PowerShell.IoT.ADXL345/README.md
+++ b/Examples/Microsoft.PowerShell.IoT.ADXL345/README.md
@@ -16,7 +16,7 @@ Wiring diagram with Raspberry Pi 3 looks like this:
 
 ### Install PowerShell Core on Raspberry Pi
 
-Installation instructions can be found [here](https://github.com/PowerShell/PowerShell/tree/master/docs/installation/linux.md#raspbian).
+Installation instructions can be found [here](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/d5263484cf6f29148b6e07c7b3e1d9376a5fd635/reference/docs-conceptual/install/install-raspbian.md#raspberry-pi-os).
 
 ### Enable I2C interface on Raspberry Pi
 

--- a/Examples/Microsoft.PowerShell.IoT.BME280/README.md
+++ b/Examples/Microsoft.PowerShell.IoT.BME280/README.md
@@ -19,7 +19,7 @@ Wiring diagram with Raspberry Pi 3 is like this:
 
 ### Install PowerShell Core on Raspberry Pi
 
-Installation instructions can be found [here](https://github.com/PowerShell/PowerShell/tree/master/docs/installation/linux.md#raspbian).
+Installation instructions can be found [here](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/d5263484cf6f29148b6e07c7b3e1d9376a5fd635/reference/docs-conceptual/install/install-raspbian.md#raspberry-pi-os).
 
 ### Enable I2C interface on Raspberry Pi
 

--- a/Examples/Microsoft.PowerShell.IoT.Fan/README.md
+++ b/Examples/Microsoft.PowerShell.IoT.Fan/README.md
@@ -21,7 +21,7 @@ Connect transistor gate to GPIO 17 (BCM schema) on Raspberry Pi.
 
 ### Install PowerShell Core on Raspberry Pi
 
-Installation instructions can be found [here](https://github.com/PowerShell/PowerShell/tree/master/docs/installation/linux.md#raspbian).
+Installation instructions can be found [here](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/d5263484cf6f29148b6e07c7b3e1d9376a5fd635/reference/docs-conceptual/install/install-raspbian.md#raspberry-pi-os).
 
 ### Start Powershell and install modules
 

--- a/Examples/Microsoft.PowerShell.IoT.LED/README.md
+++ b/Examples/Microsoft.PowerShell.IoT.LED/README.md
@@ -23,7 +23,7 @@ Hardware pieces:
 
 ### Install PowerShell Core on Raspberry Pi
 
-Installation instructions can be found [here](https://github.com/PowerShell/PowerShell/tree/master/docs/installation/linux.md#raspbian).
+Installation instructions can be found [here](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/d5263484cf6f29148b6e07c7b3e1d9376a5fd635/reference/docs-conceptual/install/install-raspbian.md#raspberry-pi-os).
 
 ### Start Powershell and install modules
 

--- a/Examples/Microsoft.PowerShell.IoT.Plant/README.md
+++ b/Examples/Microsoft.PowerShell.IoT.Plant/README.md
@@ -32,7 +32,7 @@ Wiring diagram will be published shortly.
 
 ### Install PowerShell Core on Raspberry Pi
 
-Installation instructions can be found [here](https://github.com/PowerShell/PowerShell/tree/master/docs/installation/linux.md#raspbian).
+Installation instructions can be found [here](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/d5263484cf6f29148b6e07c7b3e1d9376a5fd635/reference/docs-conceptual/install/install-raspbian.md#raspberry-pi-os).
 
 ### Start Powershell and install modules
 

--- a/Examples/Microsoft.PowerShell.IoT.SSD1306/README.md
+++ b/Examples/Microsoft.PowerShell.IoT.SSD1306/README.md
@@ -14,7 +14,7 @@ Wiring diagram with Raspberry Pi 3 is like this:
 
 ### Install PowerShell Core on Raspberry Pi
 
-Installation instructions can be found [here](https://github.com/PowerShell/PowerShell/tree/master/docs/installation/linux.md#raspbian).
+Installation instructions can be found [here](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/d5263484cf6f29148b6e07c7b3e1d9376a5fd635/reference/docs-conceptual/install/install-raspbian.md#raspberry-pi-os).
 
 ### Enable I2C interface on Raspberry Pi
 

--- a/Examples/Microsoft.PowerShell.IoT.Scroll_pHat/README.md
+++ b/Examples/Microsoft.PowerShell.IoT.Scroll_pHat/README.md
@@ -21,7 +21,7 @@ we need to set the register 1 with data 0x0D (0000 1101).
 
 ### Install PowerShell Core on Raspberry Pi
 
-Installation instructions can be found [here](https://github.com/PowerShell/PowerShell/tree/master/docs/installation/linux.md#raspbian).
+Installation instructions can be found [here](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/d5263484cf6f29148b6e07c7b3e1d9376a5fd635/reference/docs-conceptual/install/install-raspbian.md#raspberry-pi-os).
 
 ### Enable I2C interface on Raspberry Pi
 


### PR DESCRIPTION
Issue:
#68

I noticed that the links that should lead to 'Install PowerShell Core on Rasberry Pi' was not working, so I replaced them